### PR TITLE
chore: add scenario outline tests

### DIFF
--- a/packages/main/tests/test.feature
+++ b/packages/main/tests/test.feature
@@ -102,6 +102,33 @@ Feature: Basic Test
         | 5    | 8    | 13  |
         | 8    | 13   | 21  |
         | 13   | 21   | 34  |
+     
+     Scenario Outline: DataTables row: <Row>
+      Given the following datatable:
+        | Product    | Quantity |
+        | <Product1> | <Qty1>   |
+        | <Product2> | <Qty2>   |
+      Then datatable should contain "<Product1>"
+
+      Examples:
+        | Row | Product1 | Qty1 | Product2 | Qty2 |
+        | 0   | Widget A | 2    | Widget B | 3    |
+        | 1   | Widget C | 1    | Widget D | 4    |
+
+    Scenario Outline: DocStrings row: <Row>
+      And the following json:
+        """
+        {
+          "<Product1>": "<Qty1>",
+          "<Product2>": "<Qty2>"
+        }
+        """
+      Then json should contain "<Product1>"
+
+      Examples:
+        | Row | Product1 | Qty1 | Product2 | Qty2 |
+        | 0   | Widget A | 2    | Widget B | 3    |
+        | 1   | Widget C | 1    | Widget D | 4    |
 
   Rule: Vitest "todo", "skip", "fails" should work out of the box
 

--- a/packages/main/tests/tests.steps.ts
+++ b/packages/main/tests/tests.steps.ts
@@ -24,6 +24,10 @@ Given('(I have )a number {int}', (world, int) => {
   else world.numbers.push(int)
 })
 
+Given("the following datatable:", (world, datatable: DataTable) => {
+  world.datatable = datatable;
+})
+
 Given('the following numbers:', (world, numbers:DataTable) => {
   world.numbers = numbers.raw().map(n => parseInt(n[0][0]))
 })
@@ -43,6 +47,21 @@ When('I set {string} to the json value', (world, prop) => {
 Then('the sum should be {int}', (world, int) => {
   expect(world.numbers.reduce((a,b) => a + b, 0)).toBe(int)
 })
+
+Then("datatable should contain {string}", (world, value) => {
+  const values = world.datatable
+    .rows()
+    .reduce((prev, curr) => [...curr, ...prev], []);
+  expect(values.includes(value)).toBe(true);
+});
+
+Then("json should contain {string}", (world, value) => {
+  const values = [
+    ...Object.keys(world.json),
+    ...(Object.values(world.json) as string[]).map((v) => v.toString()),
+  ];
+  expect(values.includes(value)).toBe(true);
+});
 
 When('I set the data variable/value/property {string} to {string}', (world, prop, value) => {
   if (!world.data) world.data = {}


### PR DESCRIPTION
Add more tests for DataTables & DocStrings

Those tests are currently failing.
Repalce params in DataTables & DocStrings is not working.

https://github.com/dnotes/quickpickle/issues/23